### PR TITLE
Fix for multiple DNS configurations

### DIFF
--- a/root/etc/e-smith/templates/etc/dnsmasq.conf/30dhcp
+++ b/root/etc/e-smith/templates/etc/dnsmasq.conf/30dhcp
@@ -48,9 +48,11 @@
 
             my $dns_server = $_->prop('DhcpDNS') || '';
             if ($dns_server ne '') {
+               $OUT .= "dhcp-option=$interface,option:dns-server";
                foreach (split(',',$dns_server)) {
-                   $OUT .= "dhcp-option=$interface,option:dns-server,$_\n";
+                  $OUT .= ",$_";
                }
+               $OUT .= "\n";
             }
 
             my $ntp_server = $_->prop('DhcpNTP') || '';


### PR DESCRIPTION
DNSmasq wants only a single option:dns-server or the last line overrides the former ones.

Setting on the webadmin "x.x.x.x,y.y.y.y" would therefore configure DNSmasq to give a lease with only "y.y.y.y" as a DNS.

(p.s. c'è lo stesso problema anche su NethServer Enterprise!)
